### PR TITLE
Update to use https://signon-old.jgi.doe.gov

### DIFF
--- a/get_jgi_genomes.pl
+++ b/get_jgi_genomes.pl
@@ -100,7 +100,7 @@ sub signin {
     if ( -A "cookies" > 1 || !-e "cookies" ) {
         print "Logging In...\n";
         run_cmd(
-"curl --silent 'https://signon.jgi.doe.gov/signon/create' --data-urlencode 'login=$user' --data-urlencode 'password=$pass' -c cookies > /dev/null"
+"curl --silent 'https://signon-old.jgi.doe.gov/signon/create' --data-urlencode 'login=$user' --data-urlencode 'password=$pass' -c cookies > /dev/null"
         );
         print "Successfully Logged In!\n";
     }


### PR DESCRIPTION
This is a patch to update the script to use JGI's signon-old instance which retains (temporarily) support for cURL/non-browser based logins.

https://signon.jgi.doe.gov will no longer set a session cookie for CURL or other non-browser user agents, so sigon-old is a hack until a better solution is developed. It will eventually be replaced.