### PR TITLE
Fix typo in login success message

### DIFF
--- a/bin/get_jgi_genomes
+++ b/bin/get_jgi_genomes
@@ -163,7 +163,7 @@ sub check_cookie_valid {
     }
 
     if ( $logged_in eq 'true' ) {
-        print "INFO: Login Successfull!\n";
+        print "INFO: Login Successful!\n";
     }
     else {
         print


### PR DESCRIPTION
## Summary
- correct the message on successful login in `check_cookie_valid`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845bcc76d508321a342b0f6a858a63d