### PR TITLE
Add test for help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ To download transcripts of 'Trire2' from Mycocosm after you have logged in:
 ./bin/get_jgi_genomes -c signon.cookie -f -i Trire2 -t
 ```
 
+## Tests
+Run `./tests/test_help.sh` to verify that the help command works as expected.
+
 # Other Genome Download Tools
  * [Get Ensembl Genomes](https://github.com/guyleonard/get_ensembl_genomes)
 

--- a/tests/test_help.sh
+++ b/tests/test_help.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Run the help command and capture output
+output=$(./bin/get_jgi_genomes -h 2>&1)
+status=$?
+
+# Check that exit status is zero
+if [ $status -ne 0 ]; then
+  echo "Expected exit status 0, got $status" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+# Check that output contains 'Usage:'
+if ! echo "$output" | grep -q "Usage:"; then
+  echo "Help output missing 'Usage:'" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- add `tests/test_help.sh` to verify help usage
- document running the script in README

## Testing
- `bash ./tests/test_help.sh` *(fails: Can't locate List/MoreUtils.pm)*

------
https://chatgpt.com/codex/tasks/task_e_6845bcd272448321b639390696f8b608