### PR TITLE
Fix output subfolder creation

### DIFF
--- a/bin/get_jgi_genomes
+++ b/bin/get_jgi_genomes
@@ -302,6 +302,7 @@ sub parse_cosm_xml {
     if ( !-d $portal ) {
         make_path($portal);
     }
+    ensure_default_folders($portal);
 
     if ( $jgi_tax_id ne 'false' ) {
 
@@ -386,6 +387,7 @@ sub parse_zome_xml {
     if ( !-d $portal ) {
         make_path($portal);
     }
+    ensure_default_folders($portal);
 
     if ( $jgi_tax_id ne 'false' ) {
 
@@ -567,6 +569,16 @@ sub error {
 
 sub msg {
     print STDERR "@_\n";
+}
+
+# Ensure default subdirectories exist for a given portal
+sub ensure_default_folders {
+    my $path = shift;
+    my ($base) = split( '/', $path );
+    for my $dir (qw(fasta gff tab alleles)) {
+        my $folder = "$base/$dir";
+        make_path($folder) unless -d $folder;
+    }
 }
 
 sub HELP_MESSAGE {


### PR DESCRIPTION
## Summary
- add helper to create standard subdirectories
- create these folders when parsing cosm and zome XML

## Testing
- `bash tests/test_help.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845bf00ea848321b0b623d32e5f2b9d